### PR TITLE
Use specific version of omegaconf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'test-evocraft-py',
         'protobuf',
         'click',
-        'omegaconf',
+        'omegaconf==2.1.0.rc1',
         'ipython==7.23.1',
         'ipywidgets',
         'ipython-genutils==0.2.0',


### PR DESCRIPTION
## Bug repport
I tried to build with the Dockerfile, but the Docker threw an error.

```
error: omegaconf 2.1.1 is installed but omegaconf==2.1.0.rc1 is required by {'hydra-core'}
```

## Fix
We will need to use specific version of `omegaconf`, so I fixed `setup.py`. 

